### PR TITLE
Remove libraries not needed

### DIFF
--- a/nGEMApp/src/Makefile
+++ b/nGEMApp/src/Makefile
@@ -15,7 +15,6 @@ LIBRARY_IOC += nGEM
 nGEM_SRCS += nGEMDriver.cpp
 
 nGEM_LIBS += webget htmltidy asyn utilities zlib pcrecpp pcre pugixml
-nGEM_LIBS += cas gdd
 nGEM_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 nGEM_LIBS_WIN32 += oncrpc

--- a/nGEMTestApp/src/build.mak
+++ b/nGEMTestApp/src/build.mak
@@ -47,7 +47,6 @@ $(APPNAME)_LIBS += asubFunctions
 ## Add other libraries here ##
 #$(APPNAME)_LIBS += xxx
 $(APPNAME)_LIBS +=  asyn zlib efsw libjson pcrecpp pcre pugixml
-$(APPNAME)_LIBS += cas gdd 
 
 $(APPNAME)_LIBS_WIN32 += libcurl oncrpc
 $(APPNAME)_SYS_LIBS_Linux += curl


### PR DESCRIPTION
### Description of work

Minor changes for EPICS 7 compatibility, Remove libraries not needed

### To test

See ISISComputingGroup/IBEX#4599

### Acceptance criteria

* System builds with existing EPICS 3.15 
