### PR TITLE
Update README.md to Update Device URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ EPICS Support for nGEM GEM type neutron detectors from Bee Beans Technologies Co
 
 In particular, for nGEM BBTX-050 two-dimensional detector
 
-https://www.bbtech.co.jp/en/products/ngem/
+Installed model is no longer available on Bee Beans Technologies Co., Ltd's website. See the newer model of thi device here: https://www.bbtech.co.jp/en/products/thin-gem/


### PR DESCRIPTION
The URL for the detector is no longer available on the manufacturers website. Only a newer model is displayed now. Modified the URL to point to the newer model.

Old URL: https://www.bbtech.co.jp/en/products/ngem/
Proposed new URL for later model: https://www.bbtech.co.jp/en/products/thin-gem/